### PR TITLE
Support interfaces for doing Basic authentication

### DIFF
--- a/source/Octopus.Server.Extensibility.Authentication/Extensions/IDoesBasicAuthentication.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Extensions/IDoesBasicAuthentication.cs
@@ -4,6 +4,13 @@ namespace Octopus.Server.Extensibility.Authentication.Extensions
 {
     public interface IDoesBasicAuthentication
     {
+        /// <summary>
+        /// Gets the priority order for checking credentials 
+        /// </summary>
+        /// <remarks>This is important when multiple providers are enabled, as some will log things more noisily if
+        /// the credentials don't match a known user.</remarks>
+        int Priority { get; }
+
         AuthenticationUserCreateOrUpdateResult ValidateCredentials(string username, string password);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication/Extensions/IDoesBasicAuthentication.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Extensions/IDoesBasicAuthentication.cs
@@ -1,9 +1,9 @@
-﻿using Octopus.Data.Storage.User;
+﻿using Octopus.Server.Extensibility.Authentication.Storage.User;
 
 namespace Octopus.Server.Extensibility.Authentication.Extensions
 {
     public interface IDoesBasicAuthentication
     {
-        UserCreateOrUpdateResult ValidateCredentials(string username, string password);
+        AuthenticationUserCreateOrUpdateResult ValidateCredentials(string username, string password);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication/Extensions/IDoesBasicAuthentication.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Extensions/IDoesBasicAuthentication.cs
@@ -1,0 +1,9 @@
+﻿using Octopus.Data.Storage.User;
+
+namespace Octopus.Server.Extensibility.Authentication.Extensions
+{
+    public interface IDoesBasicAuthentication
+    {
+        UserCreateOrUpdateResult ValidateCredentials(string username, string password);
+    }
+}

--- a/source/Octopus.Server.Extensibility.Authentication/Extensions/ISupportsAutoUserCreationFromPrincipal.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Extensions/ISupportsAutoUserCreationFromPrincipal.cs
@@ -1,10 +1,10 @@
 ﻿using System.Security.Principal;
-using Octopus.Data.Storage.User;
+using Octopus.Server.Extensibility.Authentication.Storage.User;
 
 namespace Octopus.Server.Extensibility.Authentication.Extensions
 {
     public interface ISupportsAutoUserCreationFromPrincipal
     {
-        UserCreateOrUpdateResult GetOrCreateUser(IPrincipal principal);
+        AuthenticationUserCreateOrUpdateResult GetOrCreateUser(IPrincipal principal);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication/Octopus.Server.Extensibility.Authentication.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication/Octopus.Server.Extensibility.Authentication.csproj
@@ -61,8 +61,8 @@
       <HintPath>..\packages\Obsolete.Fody.4.1.0\lib\dotnet\Obsolete.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Octopus.Data, Version=1.0.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Data.1.0.18\lib\netstandard1.0\Octopus.Data.dll</HintPath>
+    <Reference Include="Octopus.Data, Version=1.0.19.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Data.1.0.19\lib\netstandard1.0\Octopus.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -102,6 +102,7 @@
     <Compile Include="Resources\AuthenticationProviderElement.cs" />
     <Compile Include="Resources\AuthenticationProviderThatSupportsGroups.cs" />
     <Compile Include="Resources\LoginCommand.cs" />
+    <Compile Include="Storage\User\AuthenticationUserCreateOrUpdateResult.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/source/Octopus.Server.Extensibility.Authentication/Octopus.Server.Extensibility.Authentication.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication/Octopus.Server.Extensibility.Authentication.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Extensions\IAuthenticationSchemeProvider.cs" />
     <Compile Include="Extensions\IExternalGroupsChecker.cs" />
     <Compile Include="Extensions\ISupportsAutoUserCreationFromPrincipal.cs" />
+    <Compile Include="Extensions\IDoesBasicAuthentication.cs" />
     <Compile Include="HostServices\AuthorizationResult.cs" />
     <Compile Include="HostServices\ExternalSecurityGroup.cs" />
     <Compile Include="HostServices\IAuthCookieCreator.cs" />

--- a/source/Octopus.Server.Extensibility.Authentication/Resources/AuthenticationProviderElement.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Resources/AuthenticationProviderElement.cs
@@ -18,8 +18,6 @@ namespace Octopus.Server.Extensibility.Authentication.Resources
 
         public bool FormsLoginEnabled { get; set; }
 
-        public string[] FormsUsernameIdentifiers { get; set; }
-
         public string LinkHtml { get; set; }
 
         public LinkCollection Links { get; set; }

--- a/source/Octopus.Server.Extensibility.Authentication/Storage/User/AuthenticationUserCreateOrUpdateResult.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Storage/User/AuthenticationUserCreateOrUpdateResult.cs
@@ -1,4 +1,5 @@
-﻿using Octopus.Data.Storage.User;
+﻿using Octopus.Data.Model.User;
+using Octopus.Data.Storage.User;
 
 namespace Octopus.Server.Extensibility.Authentication.Storage.User
 {
@@ -10,6 +11,10 @@ namespace Octopus.Server.Extensibility.Authentication.Storage.User
         }
 
         public AuthenticationUserCreateOrUpdateResult(string failureReason) : base(failureReason)
+        {
+        }
+
+        public AuthenticationUserCreateOrUpdateResult(IUser user) : base(user)
         {
         }
 

--- a/source/Octopus.Server.Extensibility.Authentication/Storage/User/AuthenticationUserCreateOrUpdateResult.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Storage/User/AuthenticationUserCreateOrUpdateResult.cs
@@ -5,7 +5,7 @@ namespace Octopus.Server.Extensibility.Authentication.Storage.User
 {
     public class AuthenticationUserCreateOrUpdateResult : UserCreateOrUpdateResult
     {
-        public AuthenticationUserCreateOrUpdateResult() : base((string)null)
+        public AuthenticationUserCreateOrUpdateResult() : base("Provider not enabled")
         {
             ProviderIsDisabled = true;
         }

--- a/source/Octopus.Server.Extensibility.Authentication/Storage/User/AuthenticationUserCreateOrUpdateResult.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/Storage/User/AuthenticationUserCreateOrUpdateResult.cs
@@ -1,0 +1,22 @@
+﻿using Octopus.Data.Storage.User;
+
+namespace Octopus.Server.Extensibility.Authentication.Storage.User
+{
+    public class AuthenticationUserCreateOrUpdateResult : UserCreateOrUpdateResult
+    {
+        public AuthenticationUserCreateOrUpdateResult() : base((string)null)
+        {
+            ProviderIsDisabled = true;
+        }
+
+        public AuthenticationUserCreateOrUpdateResult(string failureReason) : base(failureReason)
+        {
+        }
+
+        public AuthenticationUserCreateOrUpdateResult(UserCreateOrUpdateResult copyFrom) : base(copyFrom)
+        {
+        }
+
+        public bool ProviderIsDisabled { get; private set; }
+    }
+}

--- a/source/Octopus.Server.Extensibility.Authentication/packages.config
+++ b/source/Octopus.Server.Extensibility.Authentication/packages.config
@@ -8,7 +8,7 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
   <package id="NuGet.Versioning" version="3.4.3" targetFramework="net451" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net451" developmentDependency="true" />
-  <package id="Octopus.Data" version="1.0.18" targetFramework="net451" />
+  <package id="Octopus.Data" version="1.0.19" targetFramework="net451" />
   <package id="System.Collections" version="4.0.11" targetFramework="net452" />
   <package id="System.Runtime" version="4.1.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net452" />


### PR DESCRIPTION
Each forms provider having it's own API introduced difficulties with maintaining backward compatibility with the Client API.

These changes pave the way for returning to a single login API provided by the server, which will ask each of the IDoesBasicAuthentication implementers if they think the user's credentials are valid.  The providers are checked in a priority order and the processing short circuits immediately a provider returns Success, to prevent any noise or warnings in the log.

Relates to OctopusDeploy/Issues#2948