### PR TITLE
Add support for anti-forgery token using cookie-to-header pattern

### DIFF
--- a/source/Octopus.Server.Extensibility.Authentication/HostServices/IAuthCookieCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/HostServices/IAuthCookieCreator.cs
@@ -6,6 +6,12 @@ namespace Octopus.Server.Extensibility.Authentication.HostServices
 {
     public interface IAuthCookieCreator
     {
+        [ObsoleteEx(
+            Message = "Sorry about the immediately breaking change! We are introducing CSRF prevention using the Cookie-To-Token pattern. Calling this method will only build the authentication cookie. Please change to use the CreateAuthCookies() method which will create the correct cookies for you to add on the outbound Response object.",
+            RemoveInVersion = "3.1.0",
+            TreatAsErrorFromVersion = "3.0.0",
+            ReplacementTypeOrMember = "CreateAuthCookies")]
         INancyCookie CreateAuthCookie(NancyContext context, Guid token, bool persistant);
+        INancyCookie[] CreateAuthCookies(NancyContext context, Guid token, SessionExpiry expiry);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication/HostServices/IAuthCookieCreator.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/HostServices/IAuthCookieCreator.cs
@@ -12,6 +12,6 @@ namespace Octopus.Server.Extensibility.Authentication.HostServices
             TreatAsErrorFromVersion = "3.0.0",
             ReplacementTypeOrMember = "CreateAuthCookies")]
         INancyCookie CreateAuthCookie(NancyContext context, Guid token, bool persistant);
-        INancyCookie[] CreateAuthCookies(NancyContext context, Guid token, SessionExpiry expiry);
+        INancyCookie[] CreateAuthCookies(Request request, Guid token, SessionExpiry expiry);
     }
 }

--- a/source/Octopus.Server.Extensibility.Authentication/HostServices/SessionExpiry.cs
+++ b/source/Octopus.Server.Extensibility.Authentication/HostServices/SessionExpiry.cs
@@ -1,0 +1,8 @@
+﻿namespace Octopus.Server.Extensibility.Authentication.HostServices
+{
+    public enum SessionExpiry
+    {
+        TwentyMinutes,
+        TwentyDays
+    }
+}

--- a/source/Octopus.Server.Extensibility.Authentication/Octopus.Server.Extensibility.Authentication.csproj
+++ b/source/Octopus.Server.Extensibility.Authentication/Octopus.Server.Extensibility.Authentication.csproj
@@ -98,6 +98,7 @@
     <Compile Include="HostServices\InvalidLoginAction.cs" />
     <Compile Include="HostServices\IOctopusPrincipal.cs" />
     <Compile Include="HostServices\Requests.cs" />
+    <Compile Include="HostServices\SessionExpiry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\AuthenticationProviderElement.cs" />
     <Compile Include="Resources\AuthenticationProviderThatSupportsGroups.cs" />


### PR DESCRIPTION
See related Octopus PR: https://github.com/OctopusDeploy/OctopusDeploy/pull/847

We need to create two cookies now, not just one:

1. Auth Cookie
2. Antiforgery Cookie

I've also made the `RememberMe` or `Persistent` boolean more clear as to its effect on the cookies.