### PR TITLE
Allow external server to trigger login

### DIFF
--- a/source/AuthenticationExtensibilityTests/AuthenticationExtensibilityTests.csproj
+++ b/source/AuthenticationExtensibilityTests/AuthenticationExtensibilityTests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="Shouldly" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/AuthenticationExtensibilityTests/Web/EncodedQueryStringParserTests.cs
+++ b/source/AuthenticationExtensibilityTests/Web/EncodedQueryStringParserTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Linq;
+using NUnit.Framework;
+using Octopus.Node.Extensibility.Authentication.Web;
+using Shouldly;
+
+namespace AuthenticationExtensibilityTests.Web
+{
+    [TestFixture]
+    public class EncodedQueryStringParserTests
+    {
+        [Test]
+        public void QuestionMarkIsIgnored()
+        {
+            var str = "?param=value";
+
+            var parser = new EncodedQueryStringParser();
+
+            var results = parser.Parse(str);
+
+            results.Length.ShouldBe(1);
+            results.First().Name.ShouldBe("param");
+        }
+
+        [Test]
+        public void ValueShouldBeDecoded()
+        {
+            var str = "?iss=https%3A%2F%2Fdev-123456.oktapreview.com";
+
+            var parser = new EncodedQueryStringParser();
+
+            var results = parser.Parse(str);
+
+            results.First().Value.ShouldBe("https://dev-123456.oktapreview.com");
+        }
+
+        [Test]
+        public void MultipleParametersAreHandled()
+        {
+            var str = "?param=value&iss=https%3A%2F%2Fdev-123456.oktapreview.com";
+
+            var parser = new EncodedQueryStringParser();
+
+            var results = parser.Parse(str);
+
+            results.Length.ShouldBe(2);
+            results.First().Name.ShouldBe("param");
+            results.First().Value.ShouldBe("value");
+            results.Last().Name.ShouldBe("iss");
+            results.Last().Value.ShouldBe("https://dev-123456.oktapreview.com");
+        }
+    }
+}

--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.2</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <RootNamespace>Octopus.Server.Extensibility.Authentication</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication</AssemblyName>
     <Description>Provides the agreed authentication contracts between Octopus Server and Octopus Server Extensions.</Description>

--- a/source/Node.Extensibility.Authentication/Extensions/ICanHandleLoginParameters.cs
+++ b/source/Node.Extensibility.Authentication/Extensions/ICanHandleLoginParameters.cs
@@ -1,0 +1,9 @@
+﻿using Octopus.CoreUtilities;
+
+namespace Octopus.Node.Extensibility.Authentication.Extensions
+{
+    public interface ICanHandleLoginParameters
+    {
+        Maybe<LoginInitiatedResult> WasExternalLoginInitiated(string encodedQueryString);
+    }
+}

--- a/source/Node.Extensibility.Authentication/Extensions/LoginInitiatedResult.cs
+++ b/source/Node.Extensibility.Authentication/Extensions/LoginInitiatedResult.cs
@@ -1,0 +1,12 @@
+﻿namespace Octopus.Node.Extensibility.Authentication.Extensions
+{
+    public class LoginInitiatedResult
+    {
+        public LoginInitiatedResult(string providerName)
+        {
+            ProviderName = providerName;
+        }
+
+        public string ProviderName { get; }
+    }
+}

--- a/source/Node.Extensibility.Authentication/Node.Extensibility.Authentication.csproj
+++ b/source/Node.Extensibility.Authentication/Node.Extensibility.Authentication.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.2</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <AssemblyName>Octopus.Node.Extensibility.Authentication</AssemblyName>
     <RootNamespace>Octopus.Node.Extensibility.Authentication</RootNamespace>
     <Description>Provides the agreed contracts between Octopus server side authentication extensions.</Description>
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Octopus.CoreUtilities" Version="1.1.1" />
     <PackageReference Include="Octopus.Data" Version="3.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />

--- a/source/Node.Extensibility.Authentication/Web/EncodedQueryStringParser.cs
+++ b/source/Node.Extensibility.Authentication/Web/EncodedQueryStringParser.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using System.Net;
+
+namespace Octopus.Node.Extensibility.Authentication.Web
+{
+    public class EncodedQueryStringParser
+    {
+        public QueryStringParameter[] Parse(string encodedQueryString)
+        {
+            if (encodedQueryString.StartsWith("?"))
+                encodedQueryString = encodedQueryString.Substring(1);
+
+            var pairs = encodedQueryString.Split('&');
+
+            return pairs.Select(p =>
+                {
+                    var paramAndValue = p.Split('=');
+                    return new QueryStringParameter
+                    {
+                        Name = paramAndValue[0],
+                        Value = DecodeValue(paramAndValue[1])
+                    };
+                }
+                ).ToArray();
+        }
+
+        string DecodeValue(string encodedValue)
+        {
+            return WebUtility.UrlDecode(encodedValue);
+        }
+
+        public class QueryStringParameter
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Added interface for extensions to indicate whether an external SSO server has initiated a login to Octopus

Relates to OctopusDeploy/Issues#4943