### PR TITLE
Support typed config values

### DIFF
--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="Octopus.CoreUtilities" Version="1.1.2" />
-    <PackageReference Include="Octopus.Data" Version="3.1.2" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.3-enh-typedconfig0001" />
+    <PackageReference Include="Octopus.Data" Version="3.2.0" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.1.2" />
   </ItemGroup>
 </Project>

--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="Autofac" Version="4.6.0" />
     <PackageReference Include="Octopus.CoreUtilities" Version="1.1.2" />
     <PackageReference Include="Octopus.Data" Version="3.1.2" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.2" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="6.0.3-enh-typedconfig0001" />
   </ItemGroup>
 </Project>

--- a/source/Node.Extensibility.Authentication/Node.Extensibility.Authentication.csproj
+++ b/source/Node.Extensibility.Authentication/Node.Extensibility.Authentication.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="Octopus.CoreUtilities" Version="1.1.2" />
-    <PackageReference Include="Octopus.Data" Version="3.1.2" />
+    <PackageReference Include="Octopus.Data" Version="3.2.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Update dependencies to get https://github.com/OctopusDeploy/ServerExtensibility/pull/12
> Allow config values to use their base type (int/bool/string), rather than casting everything to a string