### PR TITLE
removing some properties off IOctopusPrincipal

### DIFF
--- a/source/Extensibility.Authentication/HostServices/IOctopusPrincipal.cs
+++ b/source/Extensibility.Authentication/HostServices/IOctopusPrincipal.cs
@@ -13,10 +13,8 @@ namespace Octopus.Server.Extensibility.Authentication.HostServices
         Guid IdentificationToken { get; }
         bool IsActive { get; }
         string EstablishedWith { get; }
-        bool IsOctopusAdministrator();
         bool IsInAnyTeam(IEnumerable<string> teamIds);
         bool IsInTeam(string teamId);
         IList<string> GetTeams();
-        void VerifyIsOctopusAdministrator();
     }
 }


### PR DESCRIPTION
Permissions are being handled differently in server and these properties are no longer relevant.

We're moving them off `IOctopusPrincipal` and onto Server's internal OctopusPrincipal interface as a first step