### PR TITLE
modify session expiry enum to tinytype

### DIFF
--- a/source/Extensibility.Authentication/HostServices/SessionExpiry.cs
+++ b/source/Extensibility.Authentication/HostServices/SessionExpiry.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using Octopus.TinyTypes;
 
 namespace Octopus.Server.Extensibility.Authentication.HostServices
-{
-    public enum SessionExpiry
+{ 
+    public class SessionExpiry: TinyType<int>
     {
-        TwentyMinutes,
-        TwentyDays
+        public SessionExpiry(int seconds) : base(seconds)
+        {
+        }
     }
 }


### PR DESCRIPTION
Modify Session expiry to be a tiny type, allowing you to determine custom timeout. No name chance here, so IAuthCookieCreator changes too as it was using the enum in the method it defines