### PR TITLE
Bump versions and update createAuthCookies interface

### DIFF
--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -14,7 +14,7 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Data" Version="7.1.6-ankith-fm-addSessionsTokenToUser" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.210-ankith-fm-bumpData" />
+    <PackageReference Include="Octopus.Data" Version="7.1.145-ankith-fm-addSessionsTokenToUser" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.215-ankith-fm-bumpData" />
   </ItemGroup>
 </Project>

--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -14,7 +14,7 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Data" Version="7.0.0" />
+    <PackageReference Include="Octopus.Data" Version="7.1.6-ankith-fm-addSessionsTokenToUser" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.210-ankith-fm-bumpData" />
   </ItemGroup>
 </Project>

--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -15,6 +15,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="7.0.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.0.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.210-ankith-fm-bumpData" />
   </ItemGroup>
 </Project>

--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -14,7 +14,7 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Data" Version="7.1.145-ankith-fm-addSessionsTokenToUser" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.215-ankith-fm-bumpData" />
+    <PackageReference Include="Octopus.Data" Version="7.1.166" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="14.3.231" />
   </ItemGroup>
 </Project>

--- a/source/Extensibility.Authentication/HostServices/IAuthCookieCreator.cs
+++ b/source/Extensibility.Authentication/HostServices/IAuthCookieCreator.cs
@@ -6,6 +6,7 @@ namespace Octopus.Server.Extensibility.Authentication.HostServices
     public interface IAuthCookieCreator
     {
         OctoCookie[] CreateAuthCookies(Guid token,
+            Guid sessionsToken,
             TimeSpan expiry,
             bool requestAppearsToBeHttps,
             bool? forceSecureCookie = null);


### PR DESCRIPTION
Related to - https://github.com/OctopusDeploy/Issues/issues/7306

auth providers updates -

LdapAuthenticationProvider - https://github.com/OctopusDeploy/LdapAuthenticationProvider/pull/63
DirectoryServicesAuthenticationProvider - https://github.com/OctopusDeploy/DirectoryServicesAuthenticationProvider/pull/70
OpenIDConnectAuthenticationProviders - https://github.com/OctopusDeploy/OpenIDConnectAuthenticationProviders/pull/63
UsernamePasswordAuthenticationProvider - https://github.com/OctopusDeploy/UsernamePasswordAuthenticationProvider/pull/22
GuestAuthenticationProvider - https://github.com/OctopusDeploy/GuestAuthenticationProvider/pull/26