### PR TITLE
Add SessionId to LoginState

### DIFF
--- a/source/Extensibility.Authentication/Resources/LoginState.cs
+++ b/source/Extensibility.Authentication/Resources/LoginState.cs
@@ -19,6 +19,6 @@ namespace Octopus.Server.Extensibility.Authentication.Resources
         /// <summary>
         /// A unique ID to store and retrieve session data from Blob storage
         /// </summary>
-        public string SessionId { get; set; } = string.Empty;
+        public Guid SessionId { get; set; }
     }
 }

--- a/source/Extensibility.Authentication/Resources/LoginState.cs
+++ b/source/Extensibility.Authentication/Resources/LoginState.cs
@@ -15,5 +15,10 @@ namespace Octopus.Server.Extensibility.Authentication.Resources
         /// connection.
         /// </summary>
         public bool UsingSecureConnection { get; set; }
+
+        /// <summary>
+        /// A unique ID to store and retrieve session data from Blob storage
+        /// </summary>
+        public string SessionId { get; set; } = string.Empty;
     }
 }


### PR DESCRIPTION
As part of moving from [implicit flow to auth code flow + PKCE](https://github.com/OctopusDeploy/Issues/issues/7141), we need a way to securely temporarily store the code verifier of a given request. To keep track of a given session we'll store a generated id in the `LoginState` which is passed from the initial request to the redirect response. This id can be used as the identifier to some data stored in our `Blob` storage.