### PR TITLE
Add end of expression to pre-release tags regex

### DIFF
--- a/octoversion.json
+++ b/octoversion.json
@@ -1,3 +1,3 @@
 {
-  "NonPreReleaseTagsRegex": "refs/heads/(main|master|release/.*)"
+  "NonPreReleaseTagsRegex": "refs/heads/(main|master|release/.*)$"
 }


### PR DESCRIPTION
Nightly builds are being versioned as release builds instead of pre-release builds since the regex matches anything with `refs/heads/main` in the branch name. This change makes it so the addition of `-nightly` to the branch name will be treated as a pre-release.