### PR TITLE
bump to net6

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
-    "sdk": {
-      "version": "6.0.300",
-      "rollForward": "latestFeature"
-    }
+  "sdk": {
+    "version": "6.0.300",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   }
-  
+} 

--- a/octoversion.json
+++ b/octoversion.json
@@ -1,3 +1,3 @@
 {
-  "NonPreReleaseTagsRegex": "refs/heads/(main|master|release/.*)$"
+  "NonPreReleaseTagsRegex": "refs/heads/(main|release/.*)$"
 }

--- a/source/AuthenticationExtensibilityTests/AuthenticationExtensibilityTests.csproj
+++ b/source/AuthenticationExtensibilityTests/AuthenticationExtensibilityTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>AuthenticationExtensibilityTests</RootNamespace>
     <AssemblyName>AuthenticationExtensibilityTests</AssemblyName>
     <Description>AuthenticationExtensibilityTests</Description>

--- a/source/Extensibility.Authentication/Extensibility.Authentication.csproj
+++ b/source/Extensibility.Authentication/Extensibility.Authentication.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Octopus.Server.Extensibility.Authentication</RootNamespace>
     <AssemblyName>Octopus.Server.Extensibility.Authentication</AssemblyName>
     <Description>Provides the agreed authentication contracts between Octopus Server and Octopus Server Extensions.</Description>


### PR DESCRIPTION
**_Are you a customer of Octopus Deploy? Please contact [our support team](https://octopus.com/support) so we can triage your PR, so that we can make sure it's handled appropriately._**

# Background

Net5 is EOL, build agents will no longer include it

# Results

bumping to net6

# How to review this PR

Quality :heavy_check_mark:

I've made a couple of unrelated quality of life improvements -  bumped global.json and removed master as release branch

# Pre-requisites

- [x] I have read [How we use GitHub Issues](https://github.com/OctopusDeploy/Issues/blob/master/docs/CONTRIBUTING.internal.md) for help deciding when and where it's appropriate to make an issue.
- [x] I have considered informing or consulting the right people, according to the [ownership map](https://whimsical.com/ownership-map-NzbiD4HJyvhC9jNJNfS6TG).
- [x] I have considered appropriate testing for my change.
