### PR TITLE
Add deprecation warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,11 @@
+> **Warning**
+>
+> **Deprecated**
+>
+> This repository has been deprecated and will be archived in the near future.
+
+# Octopus.Server.Extensibility.Authentication
+
 This repository contains the Authentication Extensibility contracts for [Octopus Deploy][1] server.
 
 ## Documentation


### PR DESCRIPTION
## Background

As part of the Dependency Consolidation project, this library has been absorbed into the Octopus Server solution. It will no longer be maintained as a separate library, and will be archived when current LTS versions of Octopus Server are out of support.

## Results

Add a deprecation warning to the README.